### PR TITLE
No pipe rotation

### DIFF
--- a/Fusion/src/Features/CritHack/CritHack.cpp
+++ b/Fusion/src/Features/CritHack/CritHack.cpp
@@ -1,7 +1,5 @@
 #include "CritHack.h"
 
-#include "../Aimbot/AutoRocketJump/AutoRocketJump.h"
-
 #define WEAPON_RANDOM_RANGE				10000
 #define TF_DAMAGE_CRIT_MULTIPLIER		3.0f
 #define TF_DAMAGE_CRIT_CHANCE			0.02f
@@ -278,6 +276,8 @@ void CCritHack::Reset()
 
 void CCritHack::Run(CTFPlayer* pLocal, CTFWeaponBase* pWeapon, CUserCmd* pCmd)
 {
+	bRunning = false;
+
 	if (!pLocal || !pWeapon || !pLocal->IsAlive() || !I::EngineClient->IsInGame())
 		return;
 
@@ -342,7 +342,10 @@ void CCritHack::Run(CTFPlayer* pLocal, CTFWeaponBase* pWeapon, CUserCmd* pCmd)
 		const bool bCanCrit = Storage[pWeapon->m_iSlot()].AvailableCrits > 0 && (!CritBanned || pWeapon->m_iSlot() == SLOT_MELEE) && !bStreamWait;
 		const bool bPressed = Vars::CritHack::ForceCrits.Value || pWeapon->m_iSlot() == SLOT_MELEE && Vars::CritHack::AlwaysMelee.Value;
 		if (bCanCrit && bPressed && closestCrit)
+		{
 			pCmd->command_number = closestCrit;
+			bRunning = true;
+		}
 		else if (Vars::CritHack::AvoidRandom.Value && closestSkip)
 			pCmd->command_number = closestSkip;
 

--- a/Fusion/src/Features/CritHack/CritHack.h
+++ b/Fusion/src/Features/CritHack/CritHack.h
@@ -50,6 +50,7 @@ public:
 	void Store();
 	void Draw(CTFPlayer* pLocal);
 
+	bool bRunning = false;
 	std::unordered_map<int, WeaponStorage> Storage = {};
 };
 

--- a/Fusion/src/Features/NoSpread/NoSpreadProjectile/NoSpreadProjectile.cpp
+++ b/Fusion/src/Features/NoSpread/NoSpreadProjectile/NoSpreadProjectile.cpp
@@ -1,4 +1,5 @@
 #include "NoSpreadProjectile.h"
+#include "../../CritHack/CritHack.h"
 
 bool CNoSpreadProjectile::ShouldRun(CTFPlayer* pLocal, CTFWeaponBase* pWeapon)
 {
@@ -47,6 +48,17 @@ void CNoSpreadProjectile::Run(CTFPlayer* pLocal, CTFWeaponBase* pWeapon, CUserCm
 		pCmd->viewangles.y -= -6 + flRand * 12.f;
 
 		G::PSilentAngles = true;
+		return;
+	}
+	case TF_WEAPON_GRENADELAUNCHER:
+	case TF_WEAPON_PIPEBOMBLAUNCHER:
+	case TF_WEAPON_CANNON:
+	{
+		// No pipe rotation
+		if ( !F::CritHack.bRunning )
+		{
+			pCmd->command_number = 132; // random seed - 317335397
+		}
 		return;
 	}
 	}

--- a/Fusion/src/Features/Simulation/ProjectileSimulation/ProjectileSimulation.cpp
+++ b/Fusion/src/Features/Simulation/ProjectileSimulation/ProjectileSimulation.cpp
@@ -300,7 +300,7 @@ bool CProjectileSimulation::Initialize(const ProjectileInfo& info, bool bSimulat
 		case TF_PROJECTILE_PIPEBOMB_PRACTICE:
 		case TF_PROJECTILE_CANNONBALL:
 			vel += up * 200.f;
-			ang_vel = { 600.f, -1200.f, 0.f };
+			ang_vel = { 600.f, Vars::Aimbot::General::NoSpread.Value ? 0.f : -1200.f, 0.f };
 			break;
 		case TF_PROJECTILE_CLEAVER:
 			vel += up * 300.f;

--- a/Fusion/src/Hooks/CTFRagdoll_CreateTFRagdoll.cpp
+++ b/Fusion/src/Hooks/CTFRagdoll_CreateTFRagdoll.cpp
@@ -2,17 +2,14 @@
 
 MAKE_SIGNATURE(CTFRagdoll_CreateTFRagdoll, "client.dll", "48 89 4C 24 ? 55 53 56 57 48 8D AC 24 ? ? ? ? B8 ? ? ? ? E8 ? ? ? ? 48 2B E0 8B 91", 0x0);
 
-#define Offset(type, ent, offset) *reinterpret_cast<type>(ent + offset)
-
-void ClearEffects(CBaseEntity* pEntity)
+void ClearEffects(CTFRagdoll* pRagdoll)
 {
-	Offset(bool*, pEntity, 4273) = false; // Gib
-	Offset(bool*, pEntity, 4274) = false; // Burning
-	Offset(bool*, pEntity, 4275) = false; // Electrocuted
-	Offset(bool*, pEntity, 4277) = false; // Dissolve
-	Offset(bool*, pEntity, 4281) = false; // Ash
-	Offset(bool*, pEntity, 4288) = false; // Gold
-	Offset(bool*, pEntity, 4289) = false; // Ice
+	pRagdoll->m_bBurning() = false;
+	pRagdoll->m_bElectrocuted() = false;
+	pRagdoll->m_bBecomeAsh() = false;
+	pRagdoll->m_bDissolving() = false;
+	pRagdoll->m_bGoldRagdoll() = false;
+	pRagdoll->m_bIceRagdoll() = false;
 }
 
 MAKE_HOOK(CTFRagdoll_CreateTFRagdoll, S::CTFRagdoll_CreateTFRagdoll(), void, __fastcall,
@@ -24,29 +21,28 @@ MAKE_HOOK(CTFRagdoll_CreateTFRagdoll, S::CTFRagdoll_CreateTFRagdoll(), void, __f
 	if (!Vars::Visuals::Ragdolls::Enabled.Value)
 		return CALL_ORIGINAL(ecx);
 
-	auto pEntity = static_cast<CBaseAnimating*>(ecx);
-	if (pEntity)
+	if (const auto& pRagdoll = reinterpret_cast< CTFRagdoll* >( ecx ))
 	{
-		if (Vars::Visuals::Ragdolls::EnemyOnly.Value)
+		if ( Vars::Visuals::Ragdolls::EnemyOnly.Value )
 		{
-			auto pLocal = H::Entities.GetLocal();
-			if (pLocal && Offset(int*, pEntity, 4208) == pLocal->m_iTeamNum()) // Team offset
+			const auto& pLocal = H::Entities.GetLocal();
+			if (pLocal && pRagdoll->m_iTeam() == pLocal->m_iTeamNum())
 				return CALL_ORIGINAL(ecx);
 		}
 
-		ClearEffects(pEntity);
+		ClearEffects(pRagdoll);
 
-		Offset(bool*, pEntity, 4274) = Vars::Visuals::Ragdolls::Effects.Value & (1 << 0);
-		Offset(bool*, pEntity, 4275) = Vars::Visuals::Ragdolls::Effects.Value & (1 << 1);
-		Offset(bool*, pEntity, 4281) = Vars::Visuals::Ragdolls::Effects.Value & (1 << 2);
-		Offset(bool*, pEntity, 4277) = Vars::Visuals::Ragdolls::Effects.Value & (1 << 3);
-		Offset(bool*, pEntity, 4288) = Vars::Visuals::Ragdolls::Type.Value == 1;
-		Offset(bool*, pEntity, 4289) = Vars::Visuals::Ragdolls::Type.Value == 2;
+		pRagdoll->m_bBurning() = Vars::Visuals::Ragdolls::Effects.Value & (1 << 0);
+		pRagdoll->m_bElectrocuted() = Vars::Visuals::Ragdolls::Effects.Value & (1 << 1);
+		pRagdoll->m_bBecomeAsh() = Vars::Visuals::Ragdolls::Effects.Value & (1 << 2);
+		pRagdoll->m_bDissolving() = Vars::Visuals::Ragdolls::Effects.Value & (1 << 3);
+		pRagdoll->m_bGoldRagdoll() = Vars::Visuals::Ragdolls::Type.Value == 1;
+		pRagdoll->m_bIceRagdoll() = Vars::Visuals::Ragdolls::Type.Value == 2;
 
-		pEntity->m_vecForce() *= Vars::Visuals::Ragdolls::Force.Value;
-		pEntity->m_vecForce().x *= Vars::Visuals::Ragdolls::ForceHorizontal.Value;
-		pEntity->m_vecForce().y *= Vars::Visuals::Ragdolls::ForceHorizontal.Value;
-		pEntity->m_vecForce().z *= Vars::Visuals::Ragdolls::ForceVertical.Value;
+		pRagdoll->m_vecForce() *= Vars::Visuals::Ragdolls::Force.Value;
+		pRagdoll->m_vecForce().x *= Vars::Visuals::Ragdolls::ForceHorizontal.Value;
+		pRagdoll->m_vecForce().y *= Vars::Visuals::Ragdolls::ForceHorizontal.Value;
+		pRagdoll->m_vecForce().z *= Vars::Visuals::Ragdolls::ForceVertical.Value;
 	}
 
 	CALL_ORIGINAL(ecx);

--- a/Fusion/src/Hooks/ModelRender_DrawModelExecute.cpp
+++ b/Fusion/src/Hooks/ModelRender_DrawModelExecute.cpp
@@ -37,11 +37,14 @@ MAKE_HOOK(ModelRender_DrawModelExecute, U::Memory.GetVFunc(I::ModelRender, 19), 
 	if (F::Chams.mEntities[pInfo.entity_index])
 		return;
 
-	if (pEntity && pEntity->GetClassID() == ETFClassID::CTFViewModel)
+	if (!I::EngineVGui->IsGameUIVisible())
 	{
-		F::Glow.RenderViewmodel(pState, pInfo, pBoneToWorld);
-		if (F::Chams.RenderViewmodel(pState, pInfo, pBoneToWorld))
-			return;
+		if (pEntity && pEntity->GetClassID() == ETFClassID::CTFViewModel)
+		{
+			F::Glow.RenderViewmodel(pState, pInfo, pBoneToWorld);
+			if (F::Chams.RenderViewmodel(pState, pInfo, pBoneToWorld))
+				return;
+		}
 	}
 
 	CALL_ORIGINAL(ecx, pState, pInfo, pBoneToWorld);


### PR DESCRIPTION
No pipe rotation is incompatible with the crithack unless someone finds a way to fill crithack cmdnums with ones that are also valid for no pipe rotation (`SDK::RandomInt(-1200, 1200) == 0`).
Also "Avoid random crits" wont work while no pipe rotation is running.